### PR TITLE
control.tpl: add Rules-Requires-Root: no

### DIFF
--- a/templates/debian/control.tpl
+++ b/templates/debian/control.tpl
@@ -16,6 +16,7 @@ Homepage: {{homepage}}{% endif %}
 Vcs-{{vcs_name}}: {{vcs_src}}{% endif %}
 {%- if vcs_browser %}
 Vcs-Browser: {{vcs_browser}}{% endif %}
+Rules-Requires-Root: no
 {%- if 'python3' in interpreters %}
 
 Package: python3-{{src_name}}


### PR DESCRIPTION
This otherwise raises the following lintian warning by default:
https://lintian.debian.org/tags/rules-do-not-require-root

We should assume that packages do not need d/rules to be run as root by
default, as this should be rare for Python software.