### PR TITLE
debianize.py: remove copyright symbol

### DIFF
--- a/pypi2deb/debianize.py
+++ b/pypi2deb/debianize.py
@@ -387,7 +387,7 @@ def changelog(dpath, ctx, env):
 @_render_template
 def copyright(dpath, ctx, env):
     if not ctx.get('deb_copyright'):
-        ctx['deb_copyright'] = "{} © {}".format(datetime.now().year, ctx['creator'])
+        ctx['deb_copyright'] = "{} {}".format(datetime.now().year, ctx['creator'])
     if ctx['license_name'] in ('Apache 2', 'Apache 2.0'):
         ctx['license_name'] = 'Apache2'
         ctx['license'] = ' See /usr/share/common-licenses/Apache-2.0'


### PR DESCRIPTION
The copyright symbol used in the file provides no value and could lead
to display errors on systems that have a poor unicode support. Just
using the dates and the names of the copyright holders should be enough.